### PR TITLE
avoiding zombie processes

### DIFF
--- a/cmd/goxhkd/binding.go
+++ b/cmd/goxhkd/binding.go
@@ -55,7 +55,13 @@ func bindCommand(x *xgbutil.XUtil, w xproto.Window, btn string, cmd []string, ru
 
 	runner := func() error {
 		log.Println("Running:", cmd)
-		return exec.Command(cmd[0], cmd[1:]...).Start() // #nosec
+		run := exec.Command(cmd[0], cmd[1:]...)
+        err := run.Start() // #nosec
+        if err != nil {
+            log.Print(err)
+        }
+        _ = run.Wait()
+        return err
 	}
 
 	if repeating {
@@ -110,10 +116,7 @@ func bindCmd(x *xgbutil.XUtil, w xproto.Window, btn string, runOnRelease bool, r
 			if runOnRelease && p {
 				return
 			}
-
-			if err = runner(); err != nil {
-				log.Print(err)
-			}
+            go runner()
 		}
 	}
 

--- a/cmd/goxhkd/binding.go
+++ b/cmd/goxhkd/binding.go
@@ -56,12 +56,12 @@ func bindCommand(x *xgbutil.XUtil, w xproto.Window, btn string, cmd []string, ru
 	runner := func() error {
 		log.Println("Running:", cmd)
 		run := exec.Command(cmd[0], cmd[1:]...)
-        err := run.Start() // #nosec
-        if err != nil {
-            log.Print(err)
-        }
-        _ = run.Wait()
-        return err
+		err := run.Start() // #nosec
+ 		if err != nil {
+			log.Print(err)
+		}
+		_ = run.Wait()
+		return err
 	}
 
 	if repeating {
@@ -116,7 +116,7 @@ func bindCmd(x *xgbutil.XUtil, w xproto.Window, btn string, runOnRelease bool, r
 			if runOnRelease && p {
 				return
 			}
-            go runner()
+			go runner()
 		}
 	}
 


### PR DESCRIPTION
when using goxhkd with things like bspwm, it left lots of zombie processes behind because it didn't wait for a command to finish.
fixed that behaviour by wrapping the command execution in a go routine and waiting for the process to finish