### PR TITLE
make multiple binds on same button optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Usage of goxhkc:
         specify a button
   -clearall
         clear all bindings
+  -multi
+        allow for multiple bindings to the same button
   -network string
         specify connection network (unix, tcp, ...) (default "unix")
   -onrelease

--- a/cmd/goxhkc/main.go
+++ b/cmd/goxhkc/main.go
@@ -51,6 +51,7 @@ func run() (err error) {
 	sh := flag.Bool("sh", false, "run command with 'sh -c ...'")
 	onRelease := flag.Bool("onrelease", false, "run command on button release")
 	repeating := flag.Bool("repeat", false, "repeatedly run command while the button is pressed")
+	multi := flag.Bool("multi", false, "allow for multiple bindings to the same button")
 	clearAll := flag.Bool("clearall", false, "clear all bindings")
 	v := flag.Bool("version", false, "print version and exit")
 	flag.Parse()
@@ -74,6 +75,12 @@ func run() (err error) {
 
 		return ErrNoAction
 	case len(flag.Args()) > 0:
+        if *multi == false {
+		    c.Call("App.Unbind", shared.Binding{
+		    	Btn:          *btn,
+		    	RunOnRelease: *onRelease,
+		    }, nil)
+        }            
 		return c.Call("App.BindCommand", shared.Binding{
 			Cmd:          flag.Args(),
 			Btn:          *btn,

--- a/cmd/goxhkd/binding.go
+++ b/cmd/goxhkd/binding.go
@@ -55,7 +55,13 @@ func bindCommand(x *xgbutil.XUtil, w xproto.Window, btn string, cmd []string, ru
 
 	runner := func() error {
 		log.Println("Running:", cmd)
-		return exec.Command(cmd[0], cmd[1:]...).Start() // #nosec
+		run := exec.Command(cmd[0], cmd[1:]...)
+        err := run.Start() // #nosec
+        if err != nil {
+            log.Print(err)
+        }
+        _ = run.Wait()
+        return err
 	}
 
 	if repeating {
@@ -110,10 +116,7 @@ func bindCmd(x *xgbutil.XUtil, w xproto.Window, btn string, runOnRelease bool, r
 			if runOnRelease && p {
 				return
 			}
-
-			if err = runner(); err != nil {
-				log.Print(err)
-			}
+            go runner()
 		}
 	}
 

--- a/cmd/goxhkd/binding.go
+++ b/cmd/goxhkd/binding.go
@@ -56,12 +56,12 @@ func bindCommand(x *xgbutil.XUtil, w xproto.Window, btn string, cmd []string, ru
 	runner := func() error {
 		log.Println("Running:", cmd)
 		run := exec.Command(cmd[0], cmd[1:]...)
-        err := run.Start() // #nosec
-        if err != nil {
-            log.Print(err)
-        }
-        _ = run.Wait()
-        return err
+		err := run.Start() // #nosec
+ 		if err != nil {
+			log.Print(err)
+		}
+		_ = run.Wait()
+		return err
 	}
 
 	if repeating {
@@ -116,7 +116,7 @@ func bindCmd(x *xgbutil.XUtil, w xproto.Window, btn string, runOnRelease bool, r
 			if runOnRelease && p {
 				return
 			}
-            go runner()
+			go runner()
 		}
 	}
 


### PR DESCRIPTION
so far creating a binding to an already bound button would just add another action unless specifically unbound beforehand.
added "-multi" flag to goxhkc to control that behaviour. now App.Unbind is called before a new binding is created, unless the -multi flag is set

